### PR TITLE
Support No Suffix

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,9 +40,12 @@ module.exports = function(opts) {
   opts = opts || {};
   var crush = opts.maximumCrush;
   
-  var suffix = opts.suffix ? '.' + opts.suffix.split('.').join('') : '.build';
-  if(opts.suffix === false || opts.suffix === ""){ //no suffix option
+  var suffix = '.build'; //true || undefined
+
+  if (opts.suffix === false || opts.suffix === ""){
     suffix = "";
+  } else if (typeof opts.suffix === 'string') {
+    suffix = '.' + opts.suffix.split('.').join('');
   }
   
   var pipe = htmlPipe

--- a/index.js
+++ b/index.js
@@ -39,7 +39,12 @@ var uglify = polyclean.uglifyJs;
 module.exports = function(opts) {
   opts = opts || {};
   var crush = opts.maximumCrush;
+  
   var suffix = opts.suffix ? '.' + opts.suffix.split('.').join('') : '.build';
+  if(opts.suffix === false || opts.suffix === ""){ //no suffix option
+    suffix = "";
+  }
+  
   var pipe = htmlPipe
   // switch between cleaning or minimizing javascript
   .pipe(crush ? uglify : leftAlign)


### PR DESCRIPTION
Suffix logic substituted `false` and `""` with default.  Considered only supporting `false`, but you can't pass in `false` from the command line.  If the user leaves the option undefined `.build` will still be appended.
